### PR TITLE
Support E6 workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,10 @@ Here are some options you can run:
 * `--output-directory [dir]`  Specify a different output subdirectory rather than "out".
 
 * `--dimensions [width]x[height]` Specify a non-standard image size if you adjust the framing within TLXClient. 
+* 
+* `--output-directory [dir]`  Specify a different output subdirectory rather than "out".
+
+* `--e6` Skip running negfix8, apply ImageMagick's -auto-level on files.  Useful when scanning "Film Color: Positive" in TLXClientDemo.
 
 ----------
 


### PR DESCRIPTION
new --e6 option that skips negfix and uses ImageMagick's -auto-level command.