### PR TITLE
Switch to saving initial pre-inversion TIFF with interleaved pixel order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.0.8
+
+Switch to saving initial TIFF with interleaved pixel order rather than rather per-channel
+
+# 0.0.7
+
+Support E6 workflow by not inverting
+
 # 0.0.6
 
 Publish to npmjs.org, update readme.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var BYTE_SIZE_TO_DIMENSIONS = { // A map of file size to the size value base to 
 };
 
 program
-  .version('0.0.7')
+  .version('0.0.8')
   .option('--output-dir [dir]', `Override the default the output sub-directory of "${OUTPUT_DIR}"`, OUTPUT_DIR)
   .option('--no-negfix', 'Skip running negfix8, leaving you with raw .tiff files for futher processing with another tool')
   .option('--no-dependency-check', 'Avoid checking for dependencies')
@@ -138,7 +138,7 @@ function convertRawToTif (name, sizeParameter) {
     extra = extra + " " + optionalAutoLevel;
   }
 
-  var cmd = `convert -size ${sizeParameter} -depth 16 -interlace plane rgb:"${name}" -gamma 2.2 ${extra} tif:"${destinationFile}"`;
+  var cmd = `convert -size ${sizeParameter} -depth 16 -interlace plane rgb:"${name}" -gamma 2.2 ${extra} -interlace none tif:"${destinationFile}"`;
 
   if (process.platform === "win32") {
     cmd = "magick " + cmd;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pakon-planar-raw-converter",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A script to convert Pakon F-135+ Planar RAW scans from TLXClientDemo into usable files via ImageMagick's Convert and NegFix8",
   "keywords": ["kodak", "pakon", "f-135", "f-135+", "TLXClientDemo", "film", "negative", "scan", "scanning", "16-bit", "raw", "planar", "linear", "imagemagick", "negfix8", "photography", "35mm", "images"],
   "main": "index.js",


### PR DESCRIPTION
Somehow, despite identical visual results, when the per-channel
pixel-order tiff is run through NegFix8, it produces a file that has a
choppy/toothy histogram in Photoshop.  It was per-channel because of
the initial `-interlace plane` flag to parse it as planar, but needs to
be then set to -`interlace none`.

Thanks to Trevor Crump on the Pakon Facebook group for bringing this to
my attention!
https://www.facebook.com/groups/PakonF135/permalink/1701517296533967/